### PR TITLE
WIP Render templates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     cloudshaper (0.1.0)
       ejson (~> 1.0.0)
+      erubis (~> 2.7.0)
       thor (~> 0.19.1)
 
 GEM
@@ -10,6 +11,7 @@ GEM
   specs:
     docile (1.1.5)
     ejson (1.0.0)
+    erubis (2.7.0)
     json (1.8.2)
     minitest (5.6.1)
     rake (10.4.2)

--- a/cloudshaper.gemspec
+++ b/cloudshaper.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'thor', '~> 0.19.1'
   spec.add_runtime_dependency 'ejson', '~> 1.0.0'
+  spec.add_runtime_dependency 'erubis', '~> 2.7.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.4'

--- a/lib/cloudshaper/aws/remote_s3.rb
+++ b/lib/cloudshaper/aws/remote_s3.rb
@@ -12,7 +12,7 @@ module Cloudshaper
 
       def config_opts_s3
         config = "-backend-config='key=#{@stack.stack_id}' "
-        config += @stack.remote['s3'].map { |k, v| "-backend-config='#{k}=#{v}'" }.join(' ')
+        config += @stack.config.remote['s3'].map { |k, v| "-backend-config='#{k}=#{v}'" }.join(' ')
         config
       end
     end

--- a/lib/cloudshaper/cli.rb
+++ b/lib/cloudshaper/cli.rb
@@ -20,10 +20,34 @@ module Cloudshaper
 
   end
 
+  class Formation < Thor
+    include Cloudshaper::StackHelper
+
+    desc 'add FORMATION STACK', 'Creates a formation for the stack'
+    def add(formation, stack)
+      stack = load_stack(stack)
+      stack.add_formation(formation)
+    end
+
+    desc 'rm FORMATION STACK', 'Removes a formation from the stack'
+    def rm(formation, stack)
+      stack = load_stack(stack)
+      stack.rm_formation(formation)
+    end
+
+    desc 'resize FORMATION STACK COUNT', 'Changes the size of a formation for a stack'
+    def resize(formation, stack, count)
+      stack = load_stack(stack)
+      stack.resize(formation, count)
+    end
+
+  end
+
+
   class Addon < Thor
     include Cloudshaper::StackHelper
 
-    desc 'add ADDON STACK', 'Adds an addon from a stack'
+    desc 'add ADDON STACK', 'Adds an addon to a stack'
     def add(addon, stack)
       stack = load_stack(stack)
       stack.add_addon(addon)
@@ -57,6 +81,9 @@ module Cloudshaper
 
     desc 'addon SUBCOMMAND', 'Manage addons'
     subcommand "addon", Addon
+
+    desc 'formation SUBCOMMAND', 'Manage formations'
+    subcommand "formation", Formation
 
     desc 'list', 'List all available stacks'
     def list

--- a/lib/cloudshaper/cli.rb
+++ b/lib/cloudshaper/cli.rb
@@ -60,9 +60,17 @@ module Cloudshaper
       stack.remote_config
     end
 
-    desc 'init', 'Initialize stacks.yml if it does not exist'
+    option :name, required: true, aliases: '-n'
+    option :template, required: true, aliases: '-t'
+    option :description,  aliases: '-d'
+    option :environment, aliases: '-e'
+    desc 'init', 'Initialize a cloudshaper stack'
     def init
-      Cloudshaper::Stacks.init
+      environment = options[:environment] || 'production'
+      desc = options[:description] || 'No description given'
+      name = options[:name]
+      template = options[:template]
+      Cloudshaper::Stacks.init(environment, desc, name, template)
       puts "Created stacks.yml, you're ready to configure your stack"
     end
 

--- a/lib/cloudshaper/command.rb
+++ b/lib/cloudshaper/command.rb
@@ -37,7 +37,7 @@ module Cloudshaper
 
     def execute
       Process.waitpid(spawn(env, @command))
-      fail 'Command failed' unless $CHILD_STATUS.to_i == 0
+      fail 'Command failed' unless $?.exitstatus == 0
     end
 
     protected
@@ -58,7 +58,7 @@ module Cloudshaper
         end
       end
 
-      "#{@@terraform_bin} #{cmd}#{" #{options}" unless options.empty?} #{@stack.root}"
+      "#{@@terraform_bin} #{cmd}#{" #{options}" unless options.empty?} #{@stack.data_dir}"
     end
   end
 end

--- a/lib/cloudshaper/config.rb
+++ b/lib/cloudshaper/config.rb
@@ -1,0 +1,141 @@
+require 'securerandom'
+
+require 'cloudshaper/stacks'
+
+module Cloudshaper
+  # Singleton to keep track of stack templates
+  module Config
+    STACK_DIR = Dir.pwd
+
+    class MalformedConfig < Exception; end
+
+    def self.stacks_dir
+      ENV['STACK_DIR'] || STACK_DIR
+    end
+
+    class TemplateConfig
+      attr_reader :tier, :quantity
+
+      def method_missing(*args)
+        nil
+      end
+    end
+
+    class Addon < TemplateConfig
+      def upgrade
+        if defined? @tier
+          @tier += 1
+        else
+          @tier = 1
+        end
+      end
+
+      def downgrade
+        if defined? @tier && @tier > 1
+          @tier -= 1
+        end
+      end
+
+    end
+
+    class Proc < TemplateConfig
+    end
+
+    class Stack
+      attr_reader :variables, :remote, :name, :uuid, :template, :description
+
+      def initialize(config)
+        @name = config.fetch('name')
+        @uuid = config.fetch('uuid')
+        @type = config.fetch('type')
+        @description = config.fetch('description')
+        @template = config.fetch('template')
+        @remote = config.fetch('remote')
+        @environment = config.fetch('environment')
+        @variables = config.fetch('variables')
+
+        @procs = config.fetch('procs').inject({}) do |procs, proc_configs|
+          proc_configs.each do |name, config|
+            procs[name] = ::Proc.new(config)
+          end
+        end
+
+        @addons = config.fetch('addons').inject({}) do |addons, addon_configs|
+          addon_configs.each do |name, config|
+            addons[name] = ::Addon.new(config)
+          end
+        end
+      end
+
+      def addon(name)
+        @addons.fetch(name)
+      end
+
+      def add_addon(addon)
+        @addons[addon] = Cloudshaper::Config::Addon.new
+      end
+
+      def rm_addon(addon)
+        @addons.delete(addon)
+      end
+
+      def get_binding
+        return binding()
+      end
+
+      def save
+        config = File.join(Cloudshaper::Config.stacks_dir, ".cloudshaper.#{@type}.yml")
+        File.open(config, 'w') do |f|
+          f.write(YAML.dump(self))
+        end
+        Cloudshaper::Config::Stack.shipit_config(name, @type)
+      end
+
+      def self.init(type, desc, name, template)
+        base_config = Cloudshaper::Config::Stack.base_stack_config(type, desc, name, template)
+        base = Cloudshaper::Config::Stack.new(base_config)
+        base.save
+      end
+
+      def self.base_stack_config(type, description, name, template)
+        {
+          'name' => name,
+          'uuid' => SecureRandom.uuid,
+          'type' => type,
+          'description' => description,
+          'template' => template,
+          'remote' => {
+            's3' => {
+              'bucket' => ENV['CLOUDSHAPER_BUCKET'] || 'quartermaster-terraform',
+              'region' => ENV['CLOUDSHAPER_BUCKET_REGION'] || 'us-east-1',
+            }
+          },
+          'environment' => {},
+          'variables' => {},
+          'procs' => {},
+          'addons' => {},
+        }
+      end
+
+      def self.shipit_config(name, environment)
+        data = <<-eos
+  depl:
+    ovride:
+      echo 'noop'
+  task
+    pl:
+      tion: "Show Plan"
+      scription: "Shows all planned changes to the infrastructure stack"
+      eps:
+      - cloudshaper plan #{name} --remote-state
+    apy:
+      tion: "Apply"
+      scription: "Applies any changes to bring the stack to the desired state"
+      eps:
+      - cloudshaper apply #{name} --remote-state
+        eos
+        File.open(File.join(Cloudshaper::Config.stacks_dir,"shipit.infra_#{environment}.yml"), 'w') { |f| f.write(data)}
+      end
+    end
+  end
+end

--- a/lib/cloudshaper/config.rb
+++ b/lib/cloudshaper/config.rb
@@ -38,7 +38,14 @@ module Cloudshaper
 
     end
 
-    class Proc < TemplateConfig
+    class Formation < TemplateConfig
+      def initialize(name)
+        @type = name
+      end
+
+      def resize(size)
+        @quantity = size
+      end
     end
 
     class Stack
@@ -54,9 +61,9 @@ module Cloudshaper
         @environment = config.fetch('environment')
         @variables = config.fetch('variables')
 
-        @procs = config.fetch('procs').inject({}) do |procs, proc_configs|
-          proc_configs.each do |name, config|
-            procs[name] = ::Proc.new(config)
+        @formations = config.fetch('formations').inject({}) do |formations, formation_configs|
+          formation_configs.each do |name, config|
+            formations[name] = ::Formation.new(config)
           end
         end
 
@@ -77,6 +84,18 @@ module Cloudshaper
 
       def rm_addon(addon)
         @addons.delete(addon)
+      end
+
+      def resize_formation(name, size)
+        @formations[name].resize(size)
+      end
+
+      def add_formation(name)
+        @formations[name] = Cloudshaper::Config::Formation.new(name)
+      end
+
+      def rm_formation(name)
+        @formations.delete(name)
       end
 
       def get_binding
@@ -112,7 +131,7 @@ module Cloudshaper
           },
           'environment' => {},
           'variables' => {},
-          'procs' => {},
+          'formations' => {},
           'addons' => {},
         }
       end

--- a/lib/cloudshaper/stack.rb
+++ b/lib/cloudshaper/stack.rb
@@ -53,6 +53,22 @@ module Cloudshaper
       Remote.new(self, :config).execute
     end
 
+    def add_formation(name)
+      @config.add_formation(name)
+      @config.save
+    end
+
+    def rm_formation(name)
+      @config.rm_formation(name)
+      @config.save
+    end
+
+    def resize(name, size)
+      @config.resize_formation(name, size)
+      @config.save
+    end
+
+
     def add_addon(addon)
       @config.add_addon(addon)
       @config.save

--- a/lib/cloudshaper/stack.rb
+++ b/lib/cloudshaper/stack.rb
@@ -78,8 +78,8 @@ Stack Directory: #{@stack_dir}
 
     def render_template(stack_config)
       template_name = stack_config.fetch('template')
-      template_config = stack_config['config'] || {}
-      template_data = Template.new(template_config).render(template_name)
+      template_config = stack_config
+      template_data = Template.render(template_config, template_name)
       FileUtils.mkdir_p(@data_dir)
       File.open(File.join(@data_dir, "#{template_name}.tf"), 'w') { |f| f.write(template_data) }
     end

--- a/lib/cloudshaper/stacks.rb
+++ b/lib/cloudshaper/stacks.rb
@@ -1,79 +1,27 @@
 require 'yaml'
-require 'securerandom'
 
 require 'cloudshaper/stack'
+require 'cloudshaper/config'
 
 module Cloudshaper
   # Singleton to keep track of stack templates
   class Stacks
-    STACK_DIR = Dir.pwd
+
     class MalformedConfig < StandardError; end
     class << self
       attr_reader :stacks
 
       def load
-        stacks = Dir["#{stacks_dir}/.cloudshaper.*.yml"]
+        stacks = Dir["#{Cloudshaper::Config.stacks_dir}/.cloudshaper.*.yml"]
         stacks.each do |stack_config|
-          spec = YAML.load(File.read(stack_config))
-          stack = Stack.load(spec)
-          @stacks[stack.name] = stack
+          config = YAML.load(File.read(stack_config))
+          stack = Cloudshaper::Stack.new(config)
+          @stacks[config.name] = stack
         end
-      end
-
-      def init(environment, desc, name, template)
-        config = File.join(stacks_dir, ".cloudshaper.#{environment}.yml")
-        fail "stack already exists at #{File.expand_path(config)}" if File.exist?(config)
-        File.open(config, 'w') do |f|
-          f.write(YAML.dump(base_stack_config(desc, name, template)))
-        end
-        shipit_config(name, environment)
-      end
-
-      def base_stack_config(description, name, template)
-        {
-          'name' => name,
-          'uuid' => SecureRandom.uuid,
-          'description' => description,
-          'template' => template,
-          'remote' => {
-            's3' => {
-              'bucket' => ENV['CLOUDSHAPER_BUCKET'] || 'quartermaster-terraform',
-              'region' => ENV['CLOUDSHAPER_BUCKET_REGION'] || 'us-east-1',
-            }
-          },
-          'environment' => {},
-          'variables' => {},
-          'procs' => {},
-          'addons' => {},
-        }
-      end
-
-      def shipit_config(name, environment)
-        data = <<-eos
-deploy:
-  override:
-    - echo 'noop'
-tasks:
-  plan:
-    action: "Show Plan"
-    description: "Shows all planned changes to the infrastructure stack"
-    steps:
-      - cloudshaper plan #{name} --remote-state
-  apply:
-    action: "Apply"
-    description: "Applies any changes to bring the stack to the desired state"
-    steps:
-      - cloudshaper apply #{name} --remote-state
-        eos
-        File.open(File.join(stacks_dir,"shipit.infra_#{environment}.yml"), 'w') { |f| f.write(data)}
       end
 
       def reset!
         @stacks ||= {}
-      end
-
-      def stacks_dir
-        ENV['STACK_DIR'] || STACK_DIR
       end
 
       def dir

--- a/lib/cloudshaper/template.rb
+++ b/lib/cloudshaper/template.rb
@@ -1,0 +1,58 @@
+require 'erb'
+require 'ostruct'
+
+module Cloudshaper
+
+  TEMPLATE_SOURCE = 'git@github.com:Shopify/terraform-modules//templates?ref=template_test'
+  CACHE_DIR = '.cloudshaper_cache'
+
+  class Template < OpenStruct
+    def render(template)
+      template_data = File.read(refresh(template))
+      rendered = ERB.new(template_data).result(binding)
+    end
+
+    def self.cache
+     ENV['CACHE_DIR'] || CACHE_DIR
+    end
+
+    def self.source
+      full_uri = (ENV['TEMPLATE_SOURCE'] || TEMPLATE_SOURCE)
+      folder = full_uri.match(/\/\/(.*)\?+/).captures.first
+      uri = full_uri.match(/(.*)\/\/+|\?+/).captures.first
+      ref_check = full_uri.match(/\?ref=(.*)/)
+      ref = (ref_check.captures.first if ref_check) || 'master'
+      {uri: uri, folder: folder, ref: ref}
+    end
+  private
+
+    # Fetch template from template source
+    def refresh(template)
+      git(clone(Template.source[:uri])) unless Dir.exist? Template.cache
+      git(fetch)
+      git(checkout(Template.source[:ref]))
+      template_path = File.join(Template.cache, Template.source[:folder], "#{template}.tf.erb")
+      fail "#{template} doesn't exist at #{template_path}" unless File.exist?(template_path)
+      template_path
+    end
+
+    def checkout(ref)
+      "-C #{Template.cache} checkout origin/#{ref}"
+    end
+
+    def clone(uri)
+      "clone #{uri} #{Template.cache}"
+    end
+
+    def fetch
+      "-C #{Template.cache} fetch "
+    end
+
+    def git(command)
+      puts command
+      Process.waitpid(spawn("git #{command}"))
+      puts $?.exitstatus
+      fail 'Command failed' unless $?.exitstatus == 0
+    end
+  end
+end

--- a/lib/cloudshaper/template.rb
+++ b/lib/cloudshaper/template.rb
@@ -1,4 +1,4 @@
-require 'erubis'
+require 'erb'
 
 module Cloudshaper
 
@@ -20,7 +20,7 @@ module Cloudshaper
       fail "#{template_file} doesn't exist" unless File.exist? template_file
 
       template_data = File.read(template_file)
-      Erubis::Eruby.new(template_data).result(config: config)
+      ERB.new(template_data).result(config.get_binding)
     end
 
     def self.cache


### PR DESCRIPTION
@thegedge this is an initial 'concept' WIP for remote templates

@wvanbergen remember when I brought up the issue of erbs for the root module? this is a concept of what that might look like

The idea is that we'd do **all** configuration from the yaml file, and that's **all** that would be in the repo. The 'template' that it specifies would be fetched remotely, and can be an erb template or a flat module file (erb doesn't care).

This should simplify things dramatically. The user should just select from a set of existing templates, and the 'config' hash for each template will be documented. The template is then fetched remotely and rendered, and that input would be passed to terraform. All of this should happen transparently, with the user never knowing or caring.
- The same syntax that terraform uses for fetching remote modules is used to fetch remote templates
- This should allow us to have extremely flexible templates, envision something like this:
  - A shared 'heroku_app' template, with erb blocks around all tuneable options, such as secrets, number of addons, etc
  - In stacks.yml, a 'config' hash, that specifies the data needed to configure each of those blocks (the minimum amount necessary)
  - Without any values in the 'config' hash, a very simple, minimal app is returned.

This makes the end user programming interface to each app simply tuning a few options in a yaml file. They could actually **never be exposed to terraform at all**. All they see is a workflow like this:
1. Add 'cloudshaper' to gemfile
2. bundle exec cloudshaper init:production heroku_app
3. Edit cloudshaper.production.yml (optional), tuning config values
4. shipit

cc @xthexder @graemej for thoughts

cc @dneufeld because this addresses the simplicity issue you brought up
